### PR TITLE
Update Security Check Function for S1

### DIFF
--- a/SwiftBelt-JXA.js
+++ b/SwiftBelt-JXA.js
@@ -89,7 +89,7 @@ function Checks(options){
 		        b = 1;
 		}
 
-		if ((allapps.includes("SentinelOne")) || (allapps.includes("sentinelone"))){
+		if ((allapps.includes("SentinelOne")) || (allapps.includes("sentinelone")) || (allapps.includes("SentinelAgent"))){
 		        results += "[+] Sentinel One agent found.\n";
 		        b = 1;
 		}


### PR DESCRIPTION
Minor fix but created PR to fix the `SecCheck` function. Found the S1 check was missing because the name changed to `SentinelAgent` in later versions. May also be able to check for `sentinel_helper` - but would need to dig into that more.

Love the tooling and appreciate the work! 😄 